### PR TITLE
wayvr: add missing ALTTAB.KEYBOARD translation key

### DIFF
--- a/wayvr/src/assets/lang/de.json
+++ b/wayvr/src/assets/lang/de.json
@@ -102,6 +102,7 @@
 		"GRAB": "Einzelnes Overlay verschieben",
 		"DASH": "Dashboard umschalten",
 		"EDIT": "Bearbeitungsmodus umschalten",
+		"KEYBOARD": "Toggle keyboard",
 		"SET": "Set wechseln",
 		"RECENTER": "Einblenden/Ausblenden/Zentrieren",
 		"GENERAL_BINDS": "Allgemeine Belegung",

--- a/wayvr/src/assets/lang/en.csv
+++ b/wayvr/src/assets/lang/en.csv
@@ -88,6 +88,7 @@ ALTTAB.GRABALL,Move entire set,Key binding action to grab and move the entire se
 ALTTAB.GRAB,Move individual overlay,Key binding action to grab and move a single overlay. “Overlay” was previously translated as “{$DEFINITIONS.OVERLAY}”
 ALTTAB.DASH,Toggle dashboard,Key binding action that toggles the dashboard. “Dashboard” was previously translated as “${DEFINITIONS.DASHBOARD}”
 ALTTAB.EDIT,Toggle edit mode,Key binding action that toggles edit mode. “Edit mode” was previously translated as “${DEFINITIONS.EDIT_MODE}”
+ALTTAB.KEYBOARD,Toggle keyboard,Key binding action that toggles the keyboard. “Keyboard” was previously translated as “${DEFINITIONS.KEYBOARD}”
 ALTTAB.SET,Switch set,Key binding action to switch between sets. “Set” was previously translated as “${DEFINITIONS.SET}”
 ALTTAB.RECENTER,Show/hide/recenter,"Key binding action to show, hide, or recenter the current set. “Set” was previously translated as “${DEFINITIONS.SET}”"
 ALTTAB.GENERAL_BINDS,General bindings,Title for key bindings that don’t need any specific criteria

--- a/wayvr/src/assets/lang/en.json
+++ b/wayvr/src/assets/lang/en.json
@@ -102,6 +102,7 @@
 		"GRAB": "Move individual overlay",
 		"DASH": "Toggle dashboard",
 		"EDIT": "Toggle edit mode",
+		"KEYBOARD": "Toggle keyboard",
 		"SET": "Switch set",
 		"RECENTER": "Show/hide/recenter",
 		"GENERAL_BINDS": "General bindings",

--- a/wayvr/src/assets/lang/es.json
+++ b/wayvr/src/assets/lang/es.json
@@ -102,6 +102,7 @@
 		"GRAB": "Mover {$DEFINITIONS.OVERLAY} individual",
 		"DASH": "Alternar panel de control",
 		"EDIT": "Alternar modo edición",
+		"KEYBOARD": "Toggle keyboard",
 		"SET": "Cambiar set",
 		"RECENTER": "Mostrar/ocultar/recentrar",
 		"GENERAL_BINDS": "Asignaciones generales",

--- a/wayvr/src/assets/lang/it.json
+++ b/wayvr/src/assets/lang/it.json
@@ -102,6 +102,7 @@
 		"GRAB": "Sposta singolo overlay",
 		"DASH": "Attiva/disattiva dashboard",
 		"EDIT": "Attiva/disattiva modalità modifica",
+		"KEYBOARD": "Toggle keyboard",
 		"SET": "Cambia set",
 		"RECENTER": "Mostra/nascondi/ricentra",
 		"GENERAL_BINDS": "Tasti generali",

--- a/wayvr/src/assets/lang/ja.json
+++ b/wayvr/src/assets/lang/ja.json
@@ -102,6 +102,7 @@
 		"GRAB": "個別のオーバーレイを移動",
 		"DASH": "ダッシュボードの切り替え",
 		"EDIT": "編集モードの切り替え",
+		"KEYBOARD": "Toggle keyboard",
 		"SET": "セットを切り替え",
 		"RECENTER": "表示/非表示/中心に配置",
 		"GENERAL_BINDS": "基本操作",

--- a/wayvr/src/assets/lang/pl.json
+++ b/wayvr/src/assets/lang/pl.json
@@ -102,6 +102,7 @@
 		"GRAB": "Przesuń pojedynczą nakładkę",
 		"DASH": "Przełącz panel sterowania",
 		"EDIT": "Przełącz tryb edycji",
+		"KEYBOARD": "Toggle keyboard",
 		"SET": "Zmień zestaw",
 		"RECENTER": "Pokaż/ukryj/wyśrodkuj",
 		"GENERAL_BINDS": "Ogólne przypisania",

--- a/wayvr/src/assets/lang/zh_CN.json
+++ b/wayvr/src/assets/lang/zh_CN.json
@@ -102,6 +102,7 @@
 		"GRAB": "移动单个覆盖层",
 		"DASH": "切换控制面板",
 		"EDIT": "切换编辑模式",
+		"KEYBOARD": "Toggle keyboard",
 		"SET": "切换组",
 		"RECENTER": "显示/隐藏/重新居中",
 		"GENERAL_BINDS": "通用按键绑定",


### PR DESCRIPTION
## Summary

The `ALTTAB.KEYBOARD` translation key is referenced by the Alt-Tab help overlay for the `T` binding (`wayvr/src/assets/gui/alttab-help.xml`), but it was missing from the language files. At runtime this logs

```
ERROR wgui::i18n: missing translation for key "ALTTAB.KEYBOARD"
```

and the "T" row in the help overlay shows an empty label.

## Changes

- Added the `ALTTAB.KEYBOARD` key (English: "Toggle keyboard") to the source template `wayvr/src/assets/lang/en.csv`
- Added the same key to `en.json` and all localized files (`de`, `es`, `it`, `ja`, `pl`, `zh_CN`) so the existing `lang_json_files_contain_all_keys` test keeps passing

## Testing

- `cargo test --all-features` passes
- `cargo build --all-features` passes